### PR TITLE
Allow interfaces having same name methods

### DIFF
--- a/prajna/lowering/statement_lowering_visitor.hpp
+++ b/prajna/lowering/statement_lowering_visitor.hpp
@@ -840,7 +840,8 @@ class StatementLoweringVisitor : public std::enable_shared_from_this<StatementLo
                     ir::FunctionType::Create(ir_undef_this_pointer_function_argument_types,
                                              ir_function->function_type->return_type);
                 auto ir_undef_this_pointer_function = ir_builder->CreateFunction(
-                    ir_function->name + "/undef", ir_undef_this_pointer_function_type);
+                    ir_interface->name + "::" + ir_function->name + "/undef",
+                    ir_undef_this_pointer_function_type);
 
                 ir_interface->undef_this_pointer_functions.insert(
                     {ir_function, ir_undef_this_pointer_function});
@@ -2481,8 +2482,9 @@ class StatementLoweringVisitor : public std::enable_shared_from_this<StatementLo
                 ir::PointerType::Create(ir_builder->current_implement_type));
             auto ir_member_function_type = ir::FunctionType::Create(
                 ir_member_function_argument_types, ir_function->function_type->return_type);
-            auto ir_member_function =
-                ir_builder->CreateFunction(ir_function->name + "/member", ir_member_function_type);
+            auto ir_member_function = ir_builder->CreateFunction(
+                ir_interface_prototype->name + "::" + ir_function->name + "/member",
+                ir_member_function_type);
             ir_member_function->name = ir_function->name;
             ir_member_function->fullname = ir_function->fullname;
 

--- a/tests/prajna_sources/interface_test.prajna
+++ b/tests/prajna_sources/interface_test.prajna
@@ -2,6 +2,10 @@ interface Say{
     func Say();
 }
 
+interface Say2{
+    func Say();
+}
+
 struct SayHi{
 }
 


### PR DESCRIPTION
Methods created for interfaces need to be uniquely identified not just by the method name, but by the combination of interface name and method name to avoid conflicts.