### PR TITLE
feat(nvgpu): add WMMA (tensor core) bindings and tests

### DIFF
--- a/builtin_packages/nvgpu_wmma.prajna
+++ b/builtin_packages/nvgpu_wmma.prajna
@@ -1,0 +1,160 @@
+// ================================================================
+// NVGPU WMMA（Tensor Core）内建绑定（m16n16k16, A/B=f16, Acc/D=f32）
+// ================================================================
+//
+// 这份文件的目标：把 NVIDIA Tensor Core 的 WMMA 指令能力，暴露为 Prajna
+// 可直接调用的一组函数（在 nvptx target 下使用）。
+//
+// 实现方式：
+// - 不走 MLIR 的 nvgpu dialect，而是直接绑定 LLVM NVVM 的官方 intrinsic：
+//     llvm.nvvm.wmma.m16n16k16.load.*
+//     llvm.nvvm.wmma.m16n16k16.mma.*
+//     llvm.nvvm.wmma.m16n16k16.store.*
+// - 由 Prajna 前端/后端保证“类型签名完全一致”，让 LLVM NVPTX 后端能够把
+//   intrinsic 选择（Select）并 lower 成 PTX 的 mma.sync 等指令。
+//
+// 为什么要这么做：
+// - WMMA intrinsic 的签名非常“苛刻”，尤其是 fragment 的表示必须匹配 LLVM 的
+//   literal struct（匿名 struct）聚合类型；如果类型不一致，LLVM 会把它当成
+//   “完全不同的类型”，从而无法选择并报错。
+//
+// 依赖的编译器侧能力（本仓库已经补齐）：
+// - @literal_struct：让 struct 在 LLVM IR 里生成 literal struct（匿名、non-packed）
+// - vec<Len, Elem>：让 `vec<2, f16>` 映射为 LLVM `<2 x half>`（常见记法 v2f16）
+//
+// 注意：
+// - WMMA 需要 GPU 架构至少 sm_70（Volta）以上；测试机上 RTX 3050 是 compute 8.6。
+// - 下方 intrinsic 名称采用 LLVM NVVM 的命名规则，并包含指针地址空间后缀：
+//   当指针地址空间为 0 时，LLVM 19/20 常见为 `.p0` 后缀。
+//
+// ================================================================
+
+// ------------------------
+// 1) WMMA Fragment 类型
+// ------------------------
+//
+// NVVM WMMA intrinsic 的 fragment 在 LLVM IR 中通常表示成“匿名 struct 聚合”，
+// 例如 A/B fragment 由 8 个 `<2 x half>` 组成，Acc/D fragment 由 8 个 f32 组成。
+// 因此这里用 @literal_struct + 明确字段列表来精确匹配签名。
+
+// A fragment：m16n16k16，row-major，元素类型 half
+@literal_struct
+struct WmmaFragA {
+    a0: vec<2, f16>; a1: vec<2, f16>; a2: vec<2, f16>; a3: vec<2, f16>;
+    a4: vec<2, f16>; a5: vec<2, f16>; a6: vec<2, f16>; a7: vec<2, f16>;
+}
+
+// B fragment：m16n16k16，col-major，元素类型 half
+@literal_struct
+struct WmmaFragB {
+    b0: vec<2, f16>; b1: vec<2, f16>; b2: vec<2, f16>; b3: vec<2, f16>;
+    b4: vec<2, f16>; b5: vec<2, f16>; b6: vec<2, f16>; b7: vec<2, f16>;
+}
+
+// Acc fragment：m16n16k16，累加/结果类型 float
+@literal_struct
+struct WmmaFragAcc {
+    c0: f32; c1: f32; c2: f32; c3: f32;
+    c4: f32; c5: f32; c6: f32; c7: f32;
+}
+
+// ------------------------
+// 2) 底层 NVVM intrinsics
+// ------------------------
+//
+// 这里声明的函数“本身不会有实现”，它们会被 transform 阶段识别为 @intrinsic，
+// 并最终在 LLVM IR 中生成对应的 `call @llvm.nvvm.*`。
+//
+// 注意：这些 intrinsic 的参数签名不是“传 fragment struct”，而经常是“展开字段”
+//（flattened），例如 mma 会把 A 的 8 个 v2f16 + B 的 8 个 v2f16 + C 的 8 个 f32
+// 展平成 24 个参数。
+
+// load A（row-major），stride 以 element 为单位（典型就是 leading dimension）
+@target("nvptx")
+@intrinsic("llvm.nvvm.wmma.m16n16k16.load.a.row.stride.f16.p0")
+func __wmma_load_a_row_stride_f16(src: ptr<f16>, stride: i32)->WmmaFragA;
+
+// load B（col-major）
+@target("nvptx")
+@intrinsic("llvm.nvvm.wmma.m16n16k16.load.b.col.stride.f16.p0")
+func __wmma_load_b_col_stride_f16(src: ptr<f16>, stride: i32)->WmmaFragB;
+
+// mma：layout=row.col，A/B=half，Acc/D=float
+//
+// 说明：LLVM 侧的 intrinsic 命名会随版本略有差异；此处使用项目当前 LLVM 版本
+// 下实际可用的名字（*.f32.f32），其含义是“输入 half，累加/输出 float”。
+@target("nvptx")
+@intrinsic("llvm.nvvm.wmma.m16n16k16.mma.row.col.f32.f32")
+func __wmma_mma_row_col_f16_f32(
+    a0: vec<2, f16>, a1: vec<2, f16>, a2: vec<2, f16>, a3: vec<2, f16>,
+    a4: vec<2, f16>, a5: vec<2, f16>, a6: vec<2, f16>, a7: vec<2, f16>,
+    b0: vec<2, f16>, b1: vec<2, f16>, b2: vec<2, f16>, b3: vec<2, f16>,
+    b4: vec<2, f16>, b5: vec<2, f16>, b6: vec<2, f16>, b7: vec<2, f16>,
+    c0: f32, c1: f32, c2: f32, c3: f32,
+    c4: f32, c5: f32, c6: f32, c7: f32)->WmmaFragAcc;
+
+// store D（row-major），stride 以 element 为单位
+@target("nvptx")
+@intrinsic("llvm.nvvm.wmma.m16n16k16.store.d.row.stride.f32.p0")
+func __wmma_store_d_row_stride_f32(
+    dst: ptr<f32>,
+    d0: f32, d1: f32, d2: f32, d3: f32,
+    d4: f32, d5: f32, d6: f32, d7: f32,
+    stride: i32);
+
+// ------------------------
+// 3) 对外封装（更易用的 API）
+// ------------------------
+//
+// 这些函数是用户侧应该调用的接口：
+// - 输入/输出以 fragment struct 作为参数
+// - 内部根据 NVVM intrinsic 的签名要求，把字段展开后调用底层 intrinsic
+
+// 用一个标量把累加 fragment 填满
+//
+// 说明：有些 LLVM 版本提供 wmma.fill，但 NVPTX 后端可能不会 lower 成 PTX。
+// 为了稳定起见，这里直接构造 struct 并赋值。
+@target("nvptx")
+@inline
+func WmmaFill_m16n16k16_acc_f32(acc: ptr<WmmaFragAcc>, value: f32) {
+    var frag: WmmaFragAcc;
+    frag.c0 = value; frag.c1 = value; frag.c2 = value; frag.c3 = value;
+    frag.c4 = value; frag.c5 = value; frag.c6 = value; frag.c7 = value;
+    acc[0] = frag;
+}
+
+// 从全局内存加载 A（row-major）
+@target("nvptx")
+@inline
+func WmmaLoadA_row_m16n16k16_f16(src: ptr<f16>, stride: i32)->WmmaFragA {
+    return __wmma_load_a_row_stride_f16(src, stride);
+}
+
+// 从全局内存加载 B（col-major）
+@target("nvptx")
+@inline
+func WmmaLoadB_col_m16n16k16_f16(src: ptr<f16>, stride: i32)->WmmaFragB {
+    return __wmma_load_b_col_stride_f16(src, stride);
+}
+
+// 执行一次 WMMA：D = A * B + C（row.col，m16n16k16）
+@target("nvptx")
+@inline
+func WmmaMma_row_col_m16n16k16_f16_f32(a: WmmaFragA, b: WmmaFragB, c: WmmaFragAcc)->WmmaFragAcc {
+    // NVVM intrinsic 需要“展平参数”，这里把 fragment 字段逐个拆出来。
+    return __wmma_mma_row_col_f16_f32(
+        a.a0, a.a1, a.a2, a.a3, a.a4, a.a5, a.a6, a.a7,
+        b.b0, b.b1, b.b2, b.b3, b.b4, b.b5, b.b6, b.b7,
+        c.c0, c.c1, c.c2, c.c3, c.c4, c.c5, c.c6, c.c7);
+}
+
+// 把 fragment 写回全局内存（row-major）
+@target("nvptx")
+@inline
+func WmmaStoreD_row_m16n16k16_f32(dst: ptr<f32>, frag: WmmaFragAcc, stride: i32) {
+    __wmma_store_d_row_stride_f32(dst,
+        frag.c0, frag.c1, frag.c2, frag.c3,
+        frag.c4, frag.c5, frag.c6, frag.c7,
+        stride);
+}
+

--- a/prajna/CMakeLists.txt
+++ b/prajna/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(prajna_config_target
     INTERFACE Boost::asio
     INTERFACE Boost::scope
     INTERFACE Boost::property_tree
+    INTERFACE Boost::multiprecision
     INTERFACE fmt::fmt
     INTERFACE nlohmann_json
 )

--- a/prajna/ast/ast.hpp
+++ b/prajna/ast/ast.hpp
@@ -295,6 +295,8 @@ struct TemplateParameter : SourceLocation {
 struct TemplateParameters : SourceLocation, std::list<TemplateParameter> {};
 
 struct Struct : SourceLocation {
+    // 支持像 @literal_struct 这样的结构体注解（用于 LLVM literal struct 等后端表示控制）。
+    AnnotationDict annotation_dict;
     Identifier name;
     std::list<Field> fields;
 };
@@ -366,7 +368,8 @@ BOOST_FUSION_ADAPT_STRUCT(prajna::ast::For, annotation_dict, index, first, last,
 BOOST_FUSION_ADAPT_STRUCT(prajna::ast::Return, expr_optional)
 BOOST_FUSION_ADAPT_STRUCT(prajna::ast::Field, name, type)
 BOOST_FUSION_ADAPT_STRUCT(prajna::ast::TemplateIdentifier, identifier, template_arguments_optional)
-BOOST_FUSION_ADAPT_STRUCT(prajna::ast::Struct, name, fields)
+// Struct 支持 annotation_dict，语法层面允许：@foo @bar("x") struct S { ... }
+BOOST_FUSION_ADAPT_STRUCT(prajna::ast::Struct, annotation_dict, name, fields)
 BOOST_FUSION_ADAPT_STRUCT(prajna::ast::Parameter, name, type)
 BOOST_FUSION_ADAPT_STRUCT(prajna::ast::FunctionHeader, annotation_dict, name, parameters,
                           return_type_optional)

--- a/prajna/ir/type.hpp
+++ b/prajna/ir/type.hpp
@@ -433,6 +433,9 @@ class StructType : public Type {
     }
 
     bool is_declaration = false;
+    // 当为 true 时，codegen 会生成 LLVM literal（匿名）struct，而不是具名 struct。
+    // 这用于精确匹配 NVVM/WMMA 等 intrinsic 在 LLVM IR 里的固定签名（literal struct 不是 identified struct）。
+    bool is_literal = false;
 };
 
 class InterfacePrototype {

--- a/prajna/parser/grammar/statement_grammar_def.hpp
+++ b/prajna/parser/grammar/statement_grammar_def.hpp
@@ -116,7 +116,9 @@ StatementGrammer<Iterator, Lexer>::StatementGrammer(const Lexer &tok,
     on_success(for_, success_handler_function);
 
     struct_.name("struct");
-    struct_ = tok.struct_ > identifier > fields;
+    // struct 支持注解：@foo @bar("x") struct S { ... }
+    // 注意这里用 >> 让解析可回溯，避免把函数/接口等前置注解误吞后无法回退。
+    struct_ = annotation_dict >> tok.struct_ > identifier > fields;
     on_error<fail>(struct_, error_handler_function);
     on_success(struct_, success_handler_function);
 

--- a/scripts/clone_submodules.sh
+++ b/scripts/clone_submodules.sh
@@ -52,6 +52,7 @@ iostreams \
 iterator \
 lexical_cast \
 locale \
+math \
 move \
 mp11 \
 mpl \

--- a/tests/prajna_sources/nvgpu/wmma_minimal.prajna
+++ b/tests/prajna_sources/nvgpu/wmma_minimal.prajna
@@ -1,0 +1,83 @@
+use ::nvgpu as gpu;
+use ::nvgpu_wmma as wmma;
+use ::test;
+
+// ------------------------------------------------------------
+// WMMA 最小测试（Tensor Core 冒烟测试）
+// ------------------------------------------------------------
+//
+// 目的：
+// - 验证 Prajna 能够：
+//   1) 表达 WMMA fragment 类型（literal struct + v2f16）
+//   2) 调用 NVVM WMMA intrinsics（load/mma/store）
+//   3) 经过 NVPTX 后端选择并生成 Tensor Core 指令
+//   4) 在 GPU 上正确执行并得到正确结果
+//
+// 配置：
+// - 计算的 tile：m16n16k16
+// - A/B：f16，累加/输出：f32
+// - A row-major，B col-major（与对应 intrinsic 匹配）
+// - 使用一个 block 的一个 warp（32 线程）执行一次 WMMA
+//
+// 期望：
+// - A 与 B 全 1：则 C 的每个元素 = sum_{k=0..15} 1*1 = 16
+//
+
+@kernel
+@target("nvptx")
+func WmmaKernel(a: ptr<f16>, b: ptr<f16>, c: ptr<f32>) {
+    // WMMA 是 warp 级别协同操作：每个 lane 持有 fragment 的一部分寄存器。
+    var tid = gpu::ThreadIndex()[0];
+
+    var frag_c: wmma::WmmaFragAcc;
+    // 累加器清零（C fragment 填 0）
+    wmma::WmmaFill_m16n16k16_acc_f32(&frag_c, 0.0f32);
+    // 直接从全局内存加载：
+    // - A：row-major，stride=16
+    // - B：col-major，stride=16
+    var frag_a: wmma::WmmaFragA = wmma::WmmaLoadA_row_m16n16k16_f16(a, 16i32);
+    var frag_b: wmma::WmmaFragB = wmma::WmmaLoadB_col_m16n16k16_f16(b, 16i32);
+    // 执行一次 Tensor Core MMA：frag_c = A*B + frag_c
+    frag_c = wmma::WmmaMma_row_col_m16n16k16_f16_f32(frag_a, frag_b, frag_c);
+    // 存回全局内存（row-major，stride=16）
+    wmma::WmmaStoreD_row_m16n16k16_f32(c, frag_c, 16i32);
+
+    if tid == 0 {
+        // 这里不做额外工作：store 已经把整个 16x16 tile 写回了全局内存。
+        // 注意：虽然这里只让 lane0 进入分支，但 store 是分支前执行的。
+    }
+}
+
+@test
+func TestWmmaMinimal() {
+    // 1) 准备 host 端输入：A/B 均为 16x16（展开成一维 256）
+    var host_a = ::Tensor<f16, 1>::Create([256]);
+    var host_b = ::Tensor<f16, 1>::Create([256]);
+    for i in 0 to 256 {
+        host_a[i] = 1.0f16;
+        host_b[i] = 1.0f16;
+    }
+
+    // 2) 拷到 GPU，并分配输出 C（f32，16x16）
+    var gpu_a = host_a.ToGpu();
+    var gpu_b = host_b.ToGpu();
+    var gpu_c = gpu::Tensor<f32, 1>::Create([256]);
+
+    // 3) 启动 kernel：一个 block，一个 warp（32 线程）
+    var GridShape = [1, 1, 1];
+    var BlockShape = [32, 1, 1]; // 一个 warp
+    WmmaKernel<|GridShape, BlockShape|>(gpu_a.data, gpu_b.data, gpu_c.data);
+    gpu::Synchronize();
+
+    // 4) 拷回 host，并校验若干位置（所有元素应该都接近 16）
+    var host_c = gpu_c.ToHost();
+    var eps = 0.1f32;
+    test::Assert((host_c[0] - 16.0f32).Abs() < eps);
+    test::Assert((host_c[5] - 16.0f32).Abs() < eps);
+    test::Assert((host_c[10] - 16.0f32).Abs() < eps);
+    test::Assert((host_c[64] - 16.0f32).Abs() < eps);
+    test::Assert((host_c[127] - 16.0f32).Abs() < eps);
+    test::Assert((host_c[128] - 16.0f32).Abs() < eps);
+    test::Assert((host_c[200] - 16.0f32).Abs() < eps);
+    test::Assert((host_c[255] - 16.0f32).Abs() < eps);
+}

--- a/tests/prajna_sources/nvgpu/wmma_tiled_gemm.prajna
+++ b/tests/prajna_sources/nvgpu/wmma_tiled_gemm.prajna
@@ -1,0 +1,110 @@
+use ::nvgpu as gpu;
+use ::nvgpu_wmma as wmma;
+use ::test;
+
+// ------------------------------------------------------------
+// WMMA 分块 GEMM 测试（多 tile、多 K 分块）
+// ------------------------------------------------------------
+//
+// 目的：
+// - 在 wmma_minimal 的基础上，再验证：
+//   1) 网格维度（多个 block）覆盖多个 16x16 输出 tile
+//   2) K 维度分块循环（多次 WMMA，累加到同一个 frag_c）
+//
+// 选择参数：
+// - M=N=K=32（所以输出是 2x2 个 tile）
+// - 每个 tile 使用一个 block 的一个 warp（32 线程）计算
+// - K=32 => k_tiles=2（每次 16）
+//
+// 期望：
+// - A/B 均为全 1：则 C 的每个元素 = K = 32
+//
+
+@kernel
+@target("nvptx")
+func WmmaTiledGemmKernel(a: ptr<f16>, b: ptr<f16>, c: ptr<f32>, k_tiles: i64, lda: i32, ldb: i32, ldc: i32) {
+    // 每个 block 计算一个 16x16 的 C tile。
+    // GridShape = [1, M/16, N/16]
+    // - BlockIndex()[1] 选择 tile 的行（tile_m）
+    // - BlockIndex()[2] 选择 tile 的列（tile_n）
+    var tile_m = gpu::BlockIndex()[1];
+    var tile_n = gpu::BlockIndex()[2];
+
+    var frag_c: wmma::WmmaFragAcc;
+    // 先把累加器清 0，然后在 K 分块循环里不断累加
+    wmma::WmmaFill_m16n16k16_acc_f32(&frag_c, 0.0f32);
+
+    for kt in 0 to k_tiles {
+        // 当前 K tile 的起始偏移（以元素计）
+        var k_off = kt * 16i64;
+        // A 的偏移：tile_m*16 行 + k_off 列
+        var a_off = tile_m * 16i64 * lda.Cast<i64>() + k_off;
+        // B 是 col-major：tile_n*16 列 + k_off 行（对应 col-major 的 leading dimension）
+        var b_off = tile_n * 16i64 * ldb.Cast<i64>() + k_off;
+
+        // 从全局内存加载当前 16x16 的 A/B 子块，并做一次 MMA 累加
+        var frag_a: wmma::WmmaFragA = wmma::WmmaLoadA_row_m16n16k16_f16(&a[a_off], lda);
+        var frag_b: wmma::WmmaFragB = wmma::WmmaLoadB_col_m16n16k16_f16(&b[b_off], ldb);
+        frag_c = wmma::WmmaMma_row_col_m16n16k16_f16_f32(frag_a, frag_b, frag_c);
+    }
+
+    // 把计算完成的 16x16 tile 写回 C（row-major）
+    var c_off = tile_m * 16i64 * ldc.Cast<i64>() + tile_n * 16i64;
+    wmma::WmmaStoreD_row_m16n16k16_f32(&c[c_off], frag_c, ldc);
+}
+
+@test
+func TestWmmaTiledGemm() {
+    // GEMM：C[M,N] = A[M,K] * B[K,N]
+    // 约定：
+    // - A：row-major
+    // - B：col-major（匹配 WmmaLoadB_col_*）
+    // - C：row-major
+    //
+    // 这里选 M=N=K=32：
+    // - 输出 C 有 2x2 个 16x16 tile（共 4 个 block）
+    // - K=32 => 每个 block 内部做 2 次 WMMA（k_tiles=2）
+    var M = 32i64;
+    var N = 32i64;
+    var K = 32i64;
+
+    // leading dimension（以元素计）
+    var lda = K.Cast<i32>();
+    var ldb = K.Cast<i32>();
+    var ldc = N.Cast<i32>();
+    var k_tiles = K / 16i64;
+
+    // 1) host 端初始化：A/B 全 1
+    var host_a = ::Tensor<f16, 1>::Create([M * K]);
+    var host_b = ::Tensor<f16, 1>::Create([K * N]);
+    for i in 0 to (M * K) {
+        host_a[i] = 1.0f16;
+    }
+    for i in 0 to (K * N) {
+        host_b[i] = 1.0f16;
+    }
+
+    // 2) 拷到 GPU，并分配输出
+    var gpu_a = host_a.ToGpu();
+    var gpu_b = host_b.ToGpu();
+    var gpu_c = gpu::Tensor<f32, 1>::Create([M * N]);
+
+    // 3) 2x2 个 block，每个 block 一个 warp
+    var GridShape = [1, M / 16i64, N / 16i64];
+    var BlockShape = [32, 1, 1]; // 一个 warp
+    WmmaTiledGemmKernel<|GridShape, BlockShape|>(gpu_a.data, gpu_b.data, gpu_c.data, k_tiles, lda, ldb, ldc);
+    gpu::Synchronize();
+
+    // 4) 校验：因为 A/B 全 1，所以每个输出元素应该等于 K（这里是 32）
+    var host_c = gpu_c.ToHost();
+    var expect = K.Cast<f32>();
+    var eps = 0.1f32;
+    // 覆盖多个 tile、多个位置，避免“只算了某个局部”也误通过。
+    test::Assert((host_c[0] - expect).Abs() < eps);               // (0,0)
+    test::Assert((host_c[31] - expect).Abs() < eps);              // (0,31)
+    test::Assert((host_c[15i64 * N + 15i64] - expect).Abs() < eps); // (15,15)
+    test::Assert((host_c[16i64 * N + 0] - expect).Abs() < eps);   // (16,0)
+    test::Assert((host_c[16i64 * N + 17i64] - expect).Abs() < eps); // (16,17)
+    test::Assert((host_c[31i64 * N + 0] - expect).Abs() < eps);   // (31,0)
+    test::Assert((host_c[M * N - 1i64] - expect).Abs() < eps);    // (31,31)
+}


### PR DESCRIPTION
本次提交为 Prajna 增加了对 NVIDIA Tensor Core（WMMA）的基础支持，并补充了对应的测试用例。

实现内容与思路：

采用“直接绑定 LLVM NVVM WMMA intrinsic”的路线，在 nvptx 目标下通过 @intrinsic 调用 [llvm.nvvm.wmma.m16n16k16.*](https://vscode-remote+ssh-002dremote-002bgalois.vscode-resource.vscode-cdn.net/home/zhangruiqi/.vscode-server/extensions/openai.chatgpt-0.5.68-linux-x64/webview/#)（load/mma/store）完成 Tensor Core MMA 运算。
为了让 LLVM 能正确选择并 lower 这些 intrinsic，需要精确匹配其 IR 类型签名：
增加 @literal_struct 能力，让特定 struct 在 LLVM IR 中生成 literal struct（non-packed），以匹配 NVVM WMMA fragment 的聚合类型签名。
增加 vec<Len, Elem> 类型构造器，用于表达 vec<2,f16>（对应 LLVM <2 x half>，即常见 v2f16），满足 WMMA intrinsic 对参数类型的要求。
在内建库中新增 nvgpu_wmma 封装，提供更易用的 WmmaLoad* / WmmaMma* / WmmaStore* / WmmaFill* API，屏蔽 intrinsic 的“参数展平”细节。
测试覆盖：

wmma_minimal：最小冒烟测试，单 warp 执行一次 m16n16k16 WMMA（A/B 全 1），验证输出约为 16。
wmma_tiled_gemm：分块 GEMM 测试，M=N=K=32，通过 2x2 tile 网格 + K 维两次累加（k_tiles=2）验证输出约为 32，并增加了更多断言覆盖不同 tile/位置。
已知限制：

目前 WMMA 的 A/B 仍从全局内存（.p0）加载，尚未实现从共享内存（shared memory, addrspace(3)）加载并调用 WMMA。后续计划补齐共享内存取址/地址空间指针表达、以及 .p3 版本 WMMA intrinsic 的支持，再新增对应测试。